### PR TITLE
feat: task 9 bff-service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,8 +101,16 @@ dist
 # TernJS port file
 .tern-port
 
+#ElasticBeans
+.elasticbeanstalk
+.ebextensions
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml
+
 package-lock.json
 **/package-lock.json
+yarn.lock
+**/yarn.lock
 .webpack/*
 **/.webpack/*
 .env*

--- a/bff-service/index.js
+++ b/bff-service/index.js
@@ -1,0 +1,59 @@
+require('dotenv').config();
+const express = require('express');
+const axios = require('axios');
+const cors = require('cors');
+const nodeCache = require('node-cache');
+const app = express();
+const cache = new nodeCache({ stdTTL: 20000, checkperiod: 20000 } );
+
+app.use(cors());
+app.use(express.json());
+
+app.all('*', async (req, res) => {
+
+  const [recipientServiceName, ...serviceQuery] = req.originalUrl.slice(1).split('/');
+  const recipientServiceURL = process.env[recipientServiceName.toUpperCase()];
+  const recipientServiceMethod = req.method;
+  const cacheKey = `${recipientServiceMethod}/${recipientServiceName}/${serviceQuery}`
+  console.log('START: ', cacheKey)
+
+if (!recipientServiceURL) {
+  res.status(502).json({ error: 'Cannot process request' });
+  return;
+}
+const inCache = cache.get(cacheKey)
+if(!!inCache){
+  res.status(inCache.status).json(inCache.data);
+  return;
+}
+try{    
+  const isBodyExist = Object.keys(req.body || {}).length > 0;
+  const requestConfig = {
+    method: req.method,
+    baseURL: recipientServiceURL,
+    url: serviceQuery.join('/'),
+  };
+
+  if (isBodyExist) {
+    requestConfig.data = req.body;
+  }
+  const response = await axios(requestConfig);
+
+  if (req.method === 'GET') {
+    cache.set(
+      cacheKey,
+      { status: response.status, data: response.data },
+    );
+  }
+
+  res.status(response.status).json(response.data);
+}catch(error){
+  console.log(`Error: ${error}`)
+  res.status(error.response.status).send(error.response.data);
+}
+})
+
+const port = process.env.PORT || 5000;
+app.listen(port, () => {
+  console.log(`server listen at port: ${port}`)
+})

--- a/bff-service/package.json
+++ b/bff-service/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "bff-service",
+  "version": "1.0.0",
+  "main": "index.js",
+  "author": "MariiaTarasiuk",
+  "license": "MIT",
+  "scripts": {
+    "start": "node ./index.js",
+    "start:serv": "nodemon ./index.js",
+    "terminate": "eb terminate --all"
+  },
+  "dependencies": {
+    "axios": "^0.21.0",
+    "cors": "^2.8.5",
+    "dotenv": "^8.2.0",
+    "express": "^4.17.1",
+    "node-cache": "^5.1.2",
+    "nodemon": "^2.0.6"
+  }
+}


### PR DESCRIPTION
- [x] A working and correct express application should be in the bff-service folder.

- [x] The bff-service should be deployed with Elastic Beanstalk. The bff-service call should be redirected to the appropriate service. The response from the bff-service should be the same as if the recipient service was called directly.

- [x] Add a cache at the bff-service level for a request to the getProductsList function of the product-service. The cache should expire in 2 minutes.

- [ ] Use NestJS to create bff-service instead of express

[bff-service url](http://mariia-tarasiuk-bff-api-dev.eu-west-1.elasticbeanstalk.com/)
[product-service url](https://0xyi26x4qh.execute-api.eu-west-1.amazonaws.com/dev/products)
[cart-service url](http://develop.eba-jmgr9esn.eu-west-1.elasticbeanstalk.com/api/profile/cart)

product example:
{
"title": "Citrus, Lime",
"description": "Limes are small in size, measuring 5-7 centimeters in height and 4-6 centimeters in diameter, and are globular to oblong in shape.",
"count": 10,
"price": 100
}

expected score - 6